### PR TITLE
test: add core unit coverage

### DIFF
--- a/bgpq4_test.go
+++ b/bgpq4_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+func TestSkipLines(t *testing.T) {
+	got := skipLines("first\nsecond\nthird\n", 2)
+	want := "third\n"
+	if got != want {
+		t.Fatalf("skipLines() = %q, want %q", got, want)
+	}
+}
+
+func TestStripHeadersForEos(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "removes first two header lines",
+			in:   "header 1\nheader 2\npermit 192.0.2.0/24\n",
+			want: "permit 192.0.2.0/24\n",
+		},
+		{
+			name: "removes deny line after headers",
+			in:   "header 1\nheader 2\ndeny any\npermit 192.0.2.0/24\n",
+			want: "permit 192.0.2.0/24\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripHeadersForEos(tt.in)
+			if got != tt.want {
+				t.Fatalf("stripHeadersForEos() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,0 +1,72 @@
+package main
+
+import "testing"
+
+func TestPrefixCacheSetAndGet(t *testing.T) {
+	var c prefixCache
+	c.init()
+
+	if got := c.get("arista", "v4", "AS123", "ARIN,RIPE"); got != "" {
+		t.Fatalf("empty cache returned %q, want empty string", got)
+	}
+
+	c.set("arista", "v4", "AS123", "ARIN,RIPE", "prefix-list output")
+	c.set("arista", "v6", "AS123", "ARIN,RIPE", "ipv6 output")
+	c.set("bird", "v4", "AS123", "ARIN,RIPE", "bird output")
+
+	tests := []struct {
+		name       string
+		vendor     string
+		addrFamily string
+		asnOrAsSet string
+		sourcesKey string
+		want       string
+	}{
+		{
+			name:       "exact key returns cached value",
+			vendor:     "arista",
+			addrFamily: "v4",
+			asnOrAsSet: "AS123",
+			sourcesKey: "ARIN,RIPE",
+			want:       "prefix-list output",
+		},
+		{
+			name:       "address family is isolated",
+			vendor:     "arista",
+			addrFamily: "v6",
+			asnOrAsSet: "AS123",
+			sourcesKey: "ARIN,RIPE",
+			want:       "ipv6 output",
+		},
+		{
+			name:       "vendor is isolated",
+			vendor:     "bird",
+			addrFamily: "v4",
+			asnOrAsSet: "AS123",
+			sourcesKey: "ARIN,RIPE",
+			want:       "bird output",
+		},
+		{
+			name:       "missing source key returns empty string",
+			vendor:     "arista",
+			addrFamily: "v4",
+			asnOrAsSet: "AS123",
+			sourcesKey: "RIPE",
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := c.get(tt.vendor, tt.addrFamily, tt.asnOrAsSet, tt.sourcesKey)
+			if got != tt.want {
+				t.Fatalf("cache get = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	c.init()
+	if got := c.get("arista", "v4", "AS123", "ARIN,RIPE"); got != "" {
+		t.Fatalf("cache get after init = %q, want empty string", got)
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestLoadConfigParsesEnvironment(t *testing.T) {
+	t.Setenv("SOURCES", "ripe,arin")
+	t.Setenv("MATCH_PARENT", "no")
+	t.Setenv("LISTEN", "127.0.0.1:9000")
+	t.Setenv("CACHE_TIME", "15m")
+	t.Setenv("ALLOW_CACHE_BYPASS", "yes")
+	t.Setenv("ALLOW_CACHE_CLEAR", "1")
+	t.Setenv("ALLOW_SOURCE_OVERRIDE", "true")
+
+	var cfg config
+	loadConfig(&cfg)
+
+	if !reflect.DeepEqual(cfg.sources, []string{"ripe", "arin"}) {
+		t.Fatalf("sources = %#v, want %#v", cfg.sources, []string{"ripe", "arin"})
+	}
+	if cfg.matchParent {
+		t.Fatal("matchParent = true, want false")
+	}
+	if cfg.listen != "127.0.0.1:9000" {
+		t.Fatalf("listen = %q, want %q", cfg.listen, "127.0.0.1:9000")
+	}
+	if cfg.cacheTime != 15*time.Minute {
+		t.Fatalf("cacheTime = %s, want 15m", cfg.cacheTime)
+	}
+	if !cfg.allowCacheBypass {
+		t.Fatal("allowCacheBypass = false, want true")
+	}
+	if !cfg.allowCacheClear {
+		t.Fatal("allowCacheClear = false, want true")
+	}
+	if !cfg.allowSourceOverride {
+		t.Fatal("allowSourceOverride = false, want true")
+	}
+}
+
+func TestParseEnvUsesDefaultWhenUnset(t *testing.T) {
+	got := parseEnv("GO_IRR_TEST_UNSET_VALUE", "fallback", func(s string) string {
+		return "parsed:" + s
+	})
+	if got != "fallback" {
+		t.Fatalf("parseEnv() = %q, want fallback", got)
+	}
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func resetHandlerState(t *testing.T) {
+	t.Helper()
+
+	oldConf := conf
+	oldCache := cache
+
+	conf = config{
+		sources:             []string{"RIPE", "ARIN", "RIPE"},
+		matchParent:         true,
+		listen:              "127.0.0.1:0",
+		cacheTime:           time.Hour,
+		allowCacheBypass:    false,
+		allowCacheClear:     false,
+		allowSourceOverride: false,
+	}
+	cache.init()
+
+	t.Cleanup(func() {
+		conf = oldConf
+		cache = oldCache
+	})
+}
+
+func TestHandleHealthcheck(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+
+	handleHealthcheck(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if rr.Body.String() != "OK" {
+		t.Fatalf("body = %q, want OK", rr.Body.String())
+	}
+}
+
+func TestHandleCacheClear(t *testing.T) {
+	resetHandlerState(t)
+	cache.set("arista", "v4", "AS123", "ARIN,RIPE", "cached")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/clearCache", nil)
+	handleCacheClear(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status with clear disabled = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+	if got := cache.get("arista", "v4", "AS123", "ARIN,RIPE"); got != "cached" {
+		t.Fatalf("cache after forbidden clear = %q, want cached", got)
+	}
+
+	conf.allowCacheClear = true
+	rr = httptest.NewRecorder()
+	handleCacheClear(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status with clear enabled = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if rr.Body.String() != "Cache cleared" {
+		t.Fatalf("body = %q, want Cache cleared", rr.Body.String())
+	}
+	if got := cache.get("arista", "v4", "AS123", "ARIN,RIPE"); got != "" {
+		t.Fatalf("cache after clear = %q, want empty string", got)
+	}
+}
+
+func TestHandleServesCachedOutputAndRenamesList(t *testing.T) {
+	resetHandlerState(t)
+	cache.set("arista", "v4", "AS123", "ARIN,RIPE", "NN permit 192.0.2.0/24\n")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/arista/v4/as123?name=CUSTOM", nil)
+	handle(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if got, want := rr.Header().Get("Content-Type"), "text/plain"; got != want {
+		t.Fatalf("content type = %q, want %q", got, want)
+	}
+	if got, want := rr.Body.String(), "CUSTOM permit 192.0.2.0/24\n"; got != want {
+		t.Fatalf("body = %q, want %q", got, want)
+	}
+}
+
+func TestHandleSourceOverrideUsesOrderIndependentCacheKey(t *testing.T) {
+	resetHandlerState(t)
+	conf.allowSourceOverride = true
+	cache.set("json", "v6", "AS208453:AS-SWEHOSTING", "ARIN,RIPE", "NN = [];\n")
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/json/v6/AS208453_AS-SWEHOSTING?sources=ripe,arin&name=PREFIXES", nil)
+	handle(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if got, want := rr.Body.String(), "PREFIXES = [];\n"; got != want {
+		t.Fatalf("body = %q, want %q", got, want)
+	}
+}
+
+func TestHandleRejectsInvalidRequests(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want int
+		conf func()
+	}{
+		{
+			name: "wrong path segment count",
+			path: "/arista/v4",
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "non AS identifier",
+			path: "/arista/v4/FOO",
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "cache bypass forbidden",
+			path: "/arista/v4/AS123?bypassCache=1",
+			want: http.StatusForbidden,
+		},
+		{
+			name: "source override forbidden",
+			path: "/arista/v4/AS123?sources=RIPE",
+			want: http.StatusForbidden,
+		},
+		{
+			name: "unknown source rejected",
+			path: "/arista/v4/AS123?sources=RIPE,UNKNOWN",
+			want: http.StatusBadRequest,
+			conf: func() {
+				conf.allowSourceOverride = true
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetHandlerState(t)
+			if tt.conf != nil {
+				tt.conf()
+			}
+
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			handle(rr, req)
+
+			if rr.Code != tt.want {
+				t.Fatalf("status = %d, want %d", rr.Code, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for config parsing, prefix cache behavior, and bgpq4 output helpers
- add HTTP handler tests for health checks, cache clearing, cached prefix output, source overrides, and invalid requests
- keep the handler success-path tests independent of the external `bgpq4` binary by pre-populating the cache

Closes #18

## Tests
- go test ./...
- go test -run 'Test(Handle|LoadConfig|PrefixCache|StripHeaders|SkipLines)' -v\n- go vet ./...\n- git diff --check